### PR TITLE
Fix link to dq-packer-demo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DQ Terraform Demo
 
-Simple proof of concept terraform scripts that will deploy the [UKHomeOffice/dq-packer-demo](UKHomeOffice/dq-packer-demo) built ami to an instance and setup a security group that allows http traffic
+Simple proof of concept terraform scripts that will deploy the [UKHomeOffice/dq-packer-demo](https://github.com/UKHomeOffice/dq-packer-demo) built ami to an instance and setup a security group that allows http traffic
 
 Requires the env vars `TF_VAR_aws_access_key` and `TF_VAR_aws_secret_key` to be set
 


### PR DESCRIPTION
The link to dq-packer-demo in the readme leads to a 404. This PR just changes the link so it points to the correct URL.